### PR TITLE
RE 포인트 조회 기능

### DIFF
--- a/hhplus-tdd-java/src/test/java/io/hhplus/tdd/point/controller/PointControllerTest.java
+++ b/hhplus-tdd-java/src/test/java/io/hhplus/tdd/point/controller/PointControllerTest.java
@@ -2,9 +2,6 @@ package io.hhplus.tdd.point.controller;
 
 import io.hhplus.tdd.point.UserPoint;
 import io.hhplus.tdd.point.repository.UserPointRepository;
-import io.hhplus.tdd.point.repository.UserPointRepositoryImpl;
-import io.hhplus.tdd.point.service.UserPointService;
-import io.hhplus.tdd.point.service.UserPointServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,6 +45,8 @@ class PointControllerTest {
 
     }
 
+
+    //기본 API의 작동 테스트
     @Test
     @DisplayName("포인트 조회 - 작동 테스트")
     void pointAPISuccessTest() throws Exception {
@@ -59,6 +58,8 @@ class PointControllerTest {
                 .andExpect(jsonPath("$.userPoint").value(point));
     }
 
+    //userId의 자료형(long)이외 값에 대한 예외 처리
+    //원래는 CustomException을 Throw하고 싶었으나 시간상 예외에 대한 테스트만 구현
     @Test
     @DisplayName("포인트 조회 - 정수 이외 테스트")
     void pointAPIParameterExceptionTest() throws Exception {
@@ -67,6 +68,9 @@ class PointControllerTest {
                 .andExpect(status().is4xxClientError());
     }
 
+    //없는 userId에 대한 예외 처리
+    //다른 분들께 물어보니 보통 없는 userId가 들어오는 경우를 제외.. 했다고는 하지만 기본적으로 있어야 하는 예외라고 생각
+    //Optional로 감싸 없는 경우를 강제로 생성(원래는 UserPointTable에 getOrDefault 함수로 인해 없는 경우 절대X)
     @Test
     @DisplayName("포인트 조회 - 없는 사용자 테스트")
     void pointAPINotFoundUserIdExceptionTest() throws Exception {

--- a/hhplus-tdd-java/src/test/java/io/hhplus/tdd/point/service/PointServiceTest.java
+++ b/hhplus-tdd-java/src/test/java/io/hhplus/tdd/point/service/PointServiceTest.java
@@ -32,6 +32,7 @@ class PointServiceTest {
         MockitoAnnotations.openMocks(this);
     }
 
+    //기본 Service의 작동 테스트
     @Test
     @DisplayName("포인트 조회 - 서비스 로직 작동 테스트")
     void getUserPointSuccessPointTest() {
@@ -46,6 +47,9 @@ class PointServiceTest {
         verify(userPointRepository, times(1)).findById(userId);
     }
 
+    //없는 userId에 대한 예외 테스트
+    //다른분들은 보통 Service전 Security 단에서 유효성 검증이 끝난다고함
+    //해당부분은 의미.. 있을지는 모를 테스트 코드
     @Test
     @DisplayName("포인트 조회 - Not Found UserId Exception 테스트")
     void getUserPointNotFoundUserIdTest(){


### PR DESCRIPTION
##  Description
주어진 Id에 해당하는 유저의 Point 조회 기능

## Test 방법
- E2E 테스트
  - 작동 테스트
  - 파라미터 오류 테스트
  - 없는 사용자 테스트
- 단위 테스트
  - 작동 테스트
  - 없는 사용자 테스트
 
## 질문 사항
Service에서 진행한 테스트에 없는 userId에 대해 특정 예외를 던졌고 이에 대한 테스트 코드를 작성했는데 다른 분들께 질문드려보니 보통은 Controller에서 이미 userId에 대한 검증은 보통 끝나 있기에 필요가 없다고 합니다.  Conroller의 경우 E2E테스트 특성상 필요하다고 생각하지만 Service에서는 해당 부분이 필요한지, 왜 필요한지 알고 싶습니다.