### PR TITLE
동시성 문제

### DIFF
--- a/hhplus-tdd-java/src/main/java/io/hhplus/tdd/ConcurrentManager.java
+++ b/hhplus-tdd-java/src/main/java/io/hhplus/tdd/ConcurrentManager.java
@@ -1,0 +1,38 @@
+package io.hhplus.tdd;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class ConcurrentManager {
+    private final ConcurrentHashMap<Long, Boolean> hashMap = new ConcurrentHashMap<>();
+
+
+    public boolean isOperation(long key){
+        return hashMap.getOrDefault(key, false);
+    }
+
+    public void startOperation(long key){
+        hashMap.put(key, true);
+    }
+
+    public void endOperation(long key){
+        hashMap.remove(key);
+    }
+
+    public boolean waitOperation(long key, long millis)  {
+        for(int i = 0; i < 10; i++){
+            if(isOperation(key)){
+                try {
+                    Thread.sleep(millis/10);
+                }catch(InterruptedException e) {
+                    throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+                }
+            }else{
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/hhplus-tdd-java/src/test/java/io/hhplus/tdd/point/ConcurrencyTest.java
+++ b/hhplus-tdd-java/src/test/java/io/hhplus/tdd/point/ConcurrencyTest.java
@@ -52,19 +52,31 @@ public class ConcurrencyTest {
     void chargePointConcurrencyTest() {
         long amount1 = 100;
         long amount2 = 200;
-        long amount3 = 300;
-        long amount4 = 400;
 
         CompletableFuture.allOf(
                 CompletableFuture.runAsync(() -> pointService.chargePoint(userId, amount1)),
                 CompletableFuture.runAsync(() -> pointService.chargePoint(userId, amount2))
-//                CompletableFuture.runAsync(() -> pointService.chargePoint(userId, amount3)),
-//                CompletableFuture.runAsync(() -> pointService.chargePoint(userId, amount4))
         ).join();
 
         UserPoint userPoint = userPointRepository.findById(userId).orElseThrow();
 
-        assertEquals(userPoint.point(), point + amount2 + amount1);
+        assertEquals(point + amount2 + amount1, userPoint.point());
+
+    }
+
+    @Test
+    void usePointConcurrencyTest() {
+        long amount1 = 100;
+        long amount2 = 200;
+
+        CompletableFuture.allOf(
+                CompletableFuture.runAsync(() -> pointService.usePoint(userId, amount1)),
+                CompletableFuture.runAsync(() -> pointService.usePoint(userId, amount2))
+        ).join();
+
+        UserPoint userPoint = userPointRepository.findById(userId).orElseThrow();
+
+        assertEquals(point - amount2 - amount1, userPoint.point());
 
     }
 }

--- a/hhplus-tdd-java/src/test/java/io/hhplus/tdd/point/ConcurrencyTest.java
+++ b/hhplus-tdd-java/src/test/java/io/hhplus/tdd/point/ConcurrencyTest.java
@@ -1,0 +1,70 @@
+package io.hhplus.tdd.point;
+
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.point.repository.PointHistoryRepository;
+import io.hhplus.tdd.point.repository.UserPointRepository;
+import io.hhplus.tdd.point.service.PointService;
+import io.hhplus.tdd.point.service.PointServiceImpl;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringJUnitConfig
+@Import(TestConfig.class)
+public class ConcurrencyTest {
+
+    @Autowired
+    private UserPointTestRepository userPointRepository;
+
+    @Autowired
+    private PointHistoryTestRepository pointHistoryRepository;
+
+    @Autowired
+    PointService pointService;
+
+    private static long userId;
+    private static long point;
+
+    @BeforeAll
+    public static void beforeAll() {
+        userId = 1L;
+        point = 1000L;
+    }
+
+    @BeforeEach
+    void setTable() {
+        userPointRepository.clear();
+        pointHistoryRepository.clear();
+
+        userPointRepository.save(new UserPoint(userId, point));
+    }
+
+    @Test
+    void chargePointConcurrencyTest() {
+        long amount1 = 100;
+        long amount2 = 200;
+        long amount3 = 300;
+        long amount4 = 400;
+
+        CompletableFuture.allOf(
+                CompletableFuture.runAsync(() -> pointService.chargePoint(userId, amount1)),
+                CompletableFuture.runAsync(() -> pointService.chargePoint(userId, amount2))
+//                CompletableFuture.runAsync(() -> pointService.chargePoint(userId, amount3)),
+//                CompletableFuture.runAsync(() -> pointService.chargePoint(userId, amount4))
+        ).join();
+
+        UserPoint userPoint = userPointRepository.findById(userId).orElseThrow();
+
+        assertEquals(userPoint.point(), point + amount2 + amount1);
+
+    }
+}

--- a/hhplus-tdd-java/src/test/java/io/hhplus/tdd/point/TestConfig.java
+++ b/hhplus-tdd-java/src/test/java/io/hhplus/tdd/point/TestConfig.java
@@ -1,5 +1,6 @@
 package io.hhplus.tdd.point;
 
+import io.hhplus.tdd.ConcurrentManager;
 import io.hhplus.tdd.point.repository.PointHistoryRepository;
 import io.hhplus.tdd.point.repository.UserPointRepository;
 import io.hhplus.tdd.point.service.PointService;
@@ -22,8 +23,16 @@ public class TestConfig {
     }
 
     @Bean
+    public ConcurrentManager concurrentManager(){
+        return new ConcurrentManager();
+    }
+
+    @Bean
     @Primary
-    public PointService pointService(UserPointRepository userPointRepository, PointHistoryRepository pointHistoryRepository) {
-        return new PointServiceImpl(userPointRepository, pointHistoryRepository);
+    public PointService pointService(UserPointRepository userPointRepository,
+                                     PointHistoryRepository pointHistoryRepository,
+                                     ConcurrentManager concurrentManager
+    ) {
+        return new PointServiceImpl(userPointRepository, pointHistoryRepository, concurrentManager);
     }
 }


### PR DESCRIPTION
## 설명
포인트 충전/사용 로직에 있어서 동시에 여러 요청이 같은 데이터에 변경을 시도 할 시 동시성 문제가 일어난다.
- 동시에 읽은 후 저장 시 서로 처리한 내용이 반영되기 전에 읽었기 때문에 실제 여러 요청 이후의 계산된 값과 저장된 값이 다른 현상 발생

Thread safe한 ConcurrentHashMap을 이용 분산락 구현
- key값을 이용 HashMap에 저장하여 해당 데이터를 사용중임을 데이터 상으로 저장
- 같은 key값에 대해 접근 시 키가 있기 때문에 특정 시간동안 기다리고 key가 없어지면 로직 처리 key가 그대로면 Exception을 Throw한다.

## 테스트 방법
- TestRepository를 구현 이용하여 테스트 환경 구성
- CompletableFuture를 이용 비동기 작업을 실행
    - 동시에 chargePoint를 별도의 스레드로 동시에 실행
- 동시성 제어 전 테스트 후 동시성 문제 확인
- 로직 처리 후 테스트 